### PR TITLE
Fix bugs in curvature computation + main/train + add reparameterization invariant profile

### DIFF
--- a/neuralgeom/default_config.py
+++ b/neuralgeom/default_config.py
@@ -119,16 +119,16 @@ for one_dataset_name in dataset_name:
         raise ValueError(f"Dataset name {one_dataset_name} not recognized.")
 
 # Ignored if dataset_name != "experimental"
-expt_id = ["41", "34"]  # hd: with head direction
-timestep_microsec = [int(1e5), int(1e6)]  # , int(1e5)]
+expt_id = ["41"]  # , "34"]  # hd: with head direction
+timestep_microsec = [int(1e5)]  # , int(1e6)]  # , int(1e5)]
 smooth = [True]  # , False]
 # Note: if there is only one gain (gain 1), it will be selected
 # even if select gain 1 is false
 select_gain_1 = [True]  # , False]  # , False]
 
 # Ignored if dataset_name == "experimental"
-n_times = [1000]  # , 2000]  # actual number of times is sqrt_ntimes ** 2
-embedding_dim = [50]  # , 5, 8, 10, 20, 50]
+n_times = [100]  # , 2000]  # actual number of times is sqrt_ntimes ** 2
+embedding_dim = [5]  # , 5, 8, 10, 20, 50]
 distortion_amp = [0.4]
 noise_var = [1e-3]  # , 1e-2, 1e-1]
 
@@ -140,7 +140,7 @@ gen_likelihood_type = "gaussian"
 scheduler = False
 log_interval = 20
 checkpt_interval = 20
-n_epochs = 150  # 200  # 150  # 240
+n_epochs = 1  # 50  # 200  # 150  # 240
 sftbeta = 4.5
 alpha = 1.0  # weight for the reconstruction term
 beta = 0.03  # 0.03  # weight for KL term
@@ -164,7 +164,7 @@ decoder_depth = [5, 10, 20, 50, 100]
 # samples are generated until a stopping condition is met.
 # Given that 8/10 gpus can run at the same time,
 # We choose a multiple of 8.
-num_samples = 256
+num_samples = 1
 sweep_metric = "test_loss"
 # Doc on tune.run:
 # https://docs.ray.io/en/latest/_modules/ray/tune/tune.html

--- a/neuralgeom/evaluate.py
+++ b/neuralgeom/evaluate.py
@@ -85,7 +85,7 @@ def get_true_immersion(config):
     return immersion
 
 
-def get_z_grid(config, n_grid_points=50):
+def get_z_grid(config, n_grid_points=30):
     if config.dataset_name in ("s1_synthetic", "experimental"):
         z_grid = torch.linspace(0, 2 * gs.pi, n_grid_points)
     elif config.dataset_name == "s2_synthetic":
@@ -123,7 +123,7 @@ def _compute_curvature(z_grid, immersion, dim, embedding_dim):
     return geodesic_dist, curv, curv_norm
 
 
-def compute_curvature_learned(model, config, embedding_dim, n_grid_points=50):
+def compute_curvature_learned(model, config, embedding_dim, n_grid_points=30):
     """Use _compute_curvature to find mean curvature profile from learned immersion"""
     z_grid = get_z_grid(config=config, n_grid_points=n_grid_points)
     immersion = get_learned_immersion(model, config)
@@ -139,7 +139,7 @@ def compute_curvature_learned(model, config, embedding_dim, n_grid_points=50):
     return z_grid, geodesic_dist, curv, curv_norm
 
 
-def compute_curvature_true(config, n_grid_points=50):
+def compute_curvature_true(config, n_grid_points=30):
     """Use compute_mean_curvature to find mean curvature profile from true immersion"""
     z_grid = get_z_grid(config=config, n_grid_points=n_grid_points)
     immersion = get_true_immersion(config)

--- a/neuralgeom/evaluate.py
+++ b/neuralgeom/evaluate.py
@@ -85,16 +85,16 @@ def get_true_immersion(config):
     return immersion
 
 
-def get_z_grid(config, num_points):
+def get_z_grid(config, n_grid_points=50):
     if config.dataset_name in ("s1_synthetic", "experimental"):
-        z_grid = torch.linspace(0, 2 * gs.pi, num_points)
+        z_grid = torch.linspace(0, 2 * gs.pi, n_grid_points)
     elif config.dataset_name == "s2_synthetic":
-        thetas = gs.linspace(0.01, gs.pi, config.n_times)
-        phis = gs.linspace(0, 2 * gs.pi, config.n_times)
+        thetas = gs.linspace(0.01, gs.pi, n_grid_points)
+        phis = gs.linspace(0, 2 * gs.pi, n_grid_points)
         z_grid = torch.cartesian_prod(thetas, phis)
     elif config.dataset_name == "t2_synthetic":
-        thetas = gs.linspace(0, 2 * gs.pi, config.n_times)
-        phis = gs.linspace(0, 2 * gs.pi, config.n_times)
+        thetas = gs.linspace(0, 2 * gs.pi, n_grid_points)
+        phis = gs.linspace(0, 2 * gs.pi, n_grid_points)
         z_grid = torch.cartesian_prod(thetas, phis)
     return z_grid
 
@@ -119,25 +119,25 @@ def _compute_curvature(z_grid, immersion, dim, embedding_dim):
     return curv, curv_norm
 
 
-def compute_curvature_learned(model, config, num_points, emb_dim):
+def compute_curvature_learned(model, config, embedding_dim, n_grid_points=50):
     """Use _compute_curvature to find mean curvature profile from learned immersion"""
-    z_grid = get_z_grid(config, num_points)
+    z_grid = get_z_grid(config=config, n_grid_points=n_grid_points)
     immersion = get_learned_immersion(model, config)
     start_time = time.time()
     curv, curv_norm = _compute_curvature(
         z_grid=z_grid,
         immersion=immersion,
         dim=config.manifold_dim,
-        embedding_dim=emb_dim,
+        embedding_dim=embedding_dim,
     )
     end_time = time.time()
     print("Computation time: " + "%.3f" % (end_time - start_time) + " seconds.")
     return z_grid, curv, curv_norm
 
 
-def compute_curvature_true(config):
+def compute_curvature_true(config, n_grid_points=50):
     """Use compute_mean_curvature to find mean curvature profile from true immersion"""
-    z_grid = get_z_grid(config, config.n_times)
+    z_grid = get_z_grid(config=config, n_grid_points=n_grid_points)
     immersion = get_true_immersion(config)
     start_time = time.time()
     curv, curv_norm = _compute_curvature(

--- a/neuralgeom/evaluate.py
+++ b/neuralgeom/evaluate.py
@@ -85,7 +85,7 @@ def get_true_immersion(config):
     return immersion
 
 
-def get_z_grid(config, n_grid_points=30):
+def get_z_grid(config, n_grid_points=100):
     if config.dataset_name in ("s1_synthetic", "experimental"):
         z_grid = torch.linspace(0, 2 * gs.pi, n_grid_points)
     elif config.dataset_name == "s2_synthetic":
@@ -112,8 +112,11 @@ def _compute_curvature(z_grid, immersion, dim, embedding_dim):
             # TODO(nina): Vectorize in geomstats to avoid this for loop
             z = torch.unsqueeze(z, dim=0)
             curv[i_z, :] = neural_metric.mean_curvature_vector(z)
-            if i_z > 1:
-                geodesic_dist[i_z] = neural_metric.dist(z0, z)
+            # Note: these lines are commented out (see PR description)
+            # as it makes the computations extremely long.
+            # Recommendation: compute these offline in a notebook
+            # if i_z > 1:
+            #     geodesic_dist[i_z] = neural_metric.dist(z0, z)
     else:
         curv = neural_metric.mean_curvature_vector(z_grid)
 
@@ -123,7 +126,7 @@ def _compute_curvature(z_grid, immersion, dim, embedding_dim):
     return geodesic_dist, curv, curv_norm
 
 
-def compute_curvature_learned(model, config, embedding_dim, n_grid_points=30):
+def compute_curvature_learned(model, config, embedding_dim, n_grid_points=100):
     """Use _compute_curvature to find mean curvature profile from learned immersion"""
     z_grid = get_z_grid(config=config, n_grid_points=n_grid_points)
     immersion = get_learned_immersion(model, config)
@@ -139,7 +142,7 @@ def compute_curvature_learned(model, config, embedding_dim, n_grid_points=30):
     return z_grid, geodesic_dist, curv, curv_norm
 
 
-def compute_curvature_true(config, n_grid_points=30):
+def compute_curvature_true(config, n_grid_points=100):
     """Use compute_mean_curvature to find mean curvature profile from true immersion"""
     z_grid = get_z_grid(config=config, n_grid_points=n_grid_points)
     immersion = get_true_immersion(config)

--- a/neuralgeom/main.py
+++ b/neuralgeom/main.py
@@ -341,36 +341,38 @@ def curvature_compute_plot_log(config, dataset, labels, model):
     print("Computing learned curvature...")
     start_time = time.time()
     z_grid, _, curv_norms_learned = evaluate.compute_curvature_learned(
-        model, config, dataset.shape[0], dataset.shape[1]
+        model=model, config=config, embedding_dim=dataset.shape[1]
     )
     print("Saving + logging learned curvature profile...")
     curv_norm_learned_profile = pd.DataFrame(
         {"z_grid": z_grid, "curv_norm_learned": curv_norms_learned}
     )
-    mean_velocities = []
-    median_velocities = []
-    std_velocities = []
-    min_velocities = []
-    max_velocities = []
-    for one_z_grid in curv_norm_learned_profile["z_grid"]:
-        selected_labels = labels[
-            np.abs((one_z_grid - labels["angles"]) % 2 * np.pi) < 0.2
-        ]
-        mean_velocities.append(np.nanmean(selected_labels["velocities"]))
-        median_velocities.append(np.nanmedian(selected_labels["velocities"]))
-        std_velocities.append(np.nanstd(selected_labels["velocities"]))
-        if len(selected_labels) == 0:
-            min_velocities.append(-1)
-            max_velocities.append(-1)
-        else:
-            min_velocities.append(np.nanmin(selected_labels["velocities"]))
-            max_velocities.append(np.nanmax(selected_labels["velocities"]))
 
-    curv_norm_learned_profile["mean_velocities"] = mean_velocities
-    curv_norm_learned_profile["median_velocities"] = median_velocities
-    curv_norm_learned_profile["std_velocities"] = std_velocities
-    curv_norm_learned_profile["min_velocities"] = min_velocities
-    curv_norm_learned_profile["max_velocities"] = max_velocities
+    if config.dataset_name == "experimental":
+        mean_velocities = []
+        median_velocities = []
+        std_velocities = []
+        min_velocities = []
+        max_velocities = []
+        for one_z_grid in curv_norm_learned_profile["z_grid"]:
+            selected_labels = labels[
+                np.abs((one_z_grid - labels["angles"]) % 2 * np.pi) < 0.2
+            ]
+            mean_velocities.append(np.nanmean(selected_labels["velocities"]))
+            median_velocities.append(np.nanmedian(selected_labels["velocities"]))
+            std_velocities.append(np.nanstd(selected_labels["velocities"]))
+            if len(selected_labels) == 0:
+                min_velocities.append(-1)
+                max_velocities.append(-1)
+            else:
+                min_velocities.append(np.nanmin(selected_labels["velocities"]))
+                max_velocities.append(np.nanmax(selected_labels["velocities"]))
+
+        curv_norm_learned_profile["mean_velocities"] = mean_velocities
+        curv_norm_learned_profile["median_velocities"] = median_velocities
+        curv_norm_learned_profile["std_velocities"] = std_velocities
+        curv_norm_learned_profile["min_velocities"] = min_velocities
+        curv_norm_learned_profile["max_velocities"] = max_velocities
 
     curv_norm_learned_profile.to_csv(
         os.path.join(

--- a/neuralgeom/main.py
+++ b/neuralgeom/main.py
@@ -340,12 +340,16 @@ def curvature_compute_plot_log(config, dataset, labels, model):
     # Compute
     print("Computing learned curvature...")
     start_time = time.time()
-    z_grid, _, curv_norms_learned = evaluate.compute_curvature_learned(
+    z_grid, geodesic_dist, _, curv_norms_learned = evaluate.compute_curvature_learned(
         model=model, config=config, embedding_dim=dataset.shape[1]
     )
     print("Saving + logging learned curvature profile...")
     curv_norm_learned_profile = pd.DataFrame(
-        {"z_grid": z_grid, "curv_norm_learned": curv_norms_learned}
+        {
+            "z_grid": z_grid,
+            "geodesic_dist": geodesic_dist,
+            "curv_norm_learned": curv_norms_learned,
+        }
     )
 
     if config.dataset_name == "experimental":
@@ -413,17 +417,17 @@ def curvature_compute_plot_log(config, dataset, labels, model):
             norm_val=None,
             profile_type="true",
         )
-    elif config.dataset_name == "experimental":
-        # HACK ALERT: Remove large curvatures
-        # Note that the full curvature profile is saved in csv
-        # The large curvatures are only removed for the plot
-        median = curv_norm_learned_profile["curv_norm_learned"].median()
-        filtered = curv_norm_learned_profile[
-            curv_norm_learned_profile["curv_norm_learned"] < 8 * median
-        ]
-        fig_curv_norms_learned_velocities = viz.plot_curvature_velocities(
-            curv_norm_learned_profile=filtered, config=config, labels=labels
-        )
+
+    # HACK ALERT: Remove large curvatures
+    # Note that the full curvature profile is saved in csv
+    # The large curvatures are only removed for the plot
+    median = curv_norm_learned_profile["curv_norm_learned"].median()
+    filtered = curv_norm_learned_profile[
+        curv_norm_learned_profile["curv_norm_learned"] < 8 * median
+    ]
+    fig_neural_manifold_learned = viz.plot_neural_manifold_learned(
+        curv_norm_learned_profile=filtered, config=config, labels=labels
+    )
     # Log
     wandb.log(
         {
@@ -446,9 +450,7 @@ def curvature_compute_plot_log(config, dataset, labels, model):
     elif config.dataset_name == "experimental":
         wandb.log(
             {
-                "fig_curv_norms_learned_velocities": wandb.Image(
-                    fig_curv_norms_learned_velocities
-                ),
+                "fig_neural_manifold_learned": wandb.Image(fig_neural_manifold_learned),
             }
         )
     plt.close("all")

--- a/neuralgeom/train.py
+++ b/neuralgeom/train.py
@@ -32,7 +32,7 @@ def train_test(model, train_loader, test_loader, optimizer, scheduler, config):
 
         test_losses.append(test_loss)
 
-        if test_loss < lowest_test_loss:
+        if epoch == 1 or test_loss < lowest_test_loss:
             lowest_test_loss = test_loss
             best_model = copy.deepcopy(model)
 

--- a/neuralgeom/viz.py
+++ b/neuralgeom/viz.py
@@ -333,31 +333,54 @@ def plot_curvature_norms(angles, curvature_norms, config, norm_val, profile_type
     return fig
 
 
-def plot_curvature_velocities(curv_norm_learned_profile, config, labels):
-    stats = [
-        "mean_velocities",
-        "median_velocities",
-        "std_velocities",
-        "min_velocities",
-        "max_velocities",
-    ]
-    cmaps = ["viridis", "viridis", "magma", "Blues", "Reds"]
-    fig, axes = plt.subplots(nrows=1, ncols=len(stats), figsize=(20, 4))
-    for i_stat, stat_velocities in enumerate(stats):
-        curv_norm_learned_profile.plot.scatter(
-            x="z_grid",
-            y="curv_norm_learned",
-            c=stat_velocities,
-            ax=axes[i_stat],
-            cmap=cmaps[i_stat],
+def plot_neural_manifold_learned(curv_norm_learned_profile, config, labels):
+
+    if config.dataset_name == "experimental":
+        stats = [
+            "mean_velocities",
+            "median_velocities",
+            "std_velocities",
+            "min_velocities",
+            "max_velocities",
+        ]
+        cmaps = ["viridis", "viridis", "magma", "Blues", "Reds"]
+
+        fig, axes = plt.subplots(
+            nrows=1,
+            ncols=len(stats),
+            figsize=(20, 4),
+            subplot_kw={"projection": "polar"},
         )
-    fig.tight_layout()
+        for i_stat, stat_velocities in enumerate(stats):
+            ax = axes[i_stat]
+            ax.scatter(
+                filtered["geodesic_dist"],
+                1 / filtered["curv_norm_learned"],
+                c=filtered[stat_velocities],
+                cmap=cmaps[i_stat],
+            )
+            ax.set_rlabel_position(-22.5)  # Move radial labels away from plotted line
+            ax.grid(True)
+            ax.set_title("Color: " + stat_velocities, va="bottom")
+            fig.tight_layout()
+    else:
+        fig, ax = plt.subplots(
+            nrows=1, ncols=1, figsize=(20, 4), subplot_kw={"projection": "polar"}
+        )
+
+        ax.scatter(
+            filtered["geodesic_dist"],
+            1 / filtered["curv_norm_learned"],
+        )
+        ax.set_rlabel_position(-22.5)  # Move radial labels away from plotted line
+        ax.grid(True)
+        fig.tight_layout()
 
     plt.savefig(
-        os.path.join(FIGURES, f"{config.results_prefix}_curvature_velocities.png")
+        os.path.join(FIGURES, f"{config.results_prefix}_neural_manifold_learned.png")
     )
     plt.savefig(
-        os.path.join(FIGURES, f"{config.results_prefix}_curvature_velocities.svg")
+        os.path.join(FIGURES, f"{config.results_prefix}_neural_manifold_learned.svg")
     )
 
     return fig

--- a/neuralgeom/viz.py
+++ b/neuralgeom/viz.py
@@ -354,10 +354,22 @@ def plot_neural_manifold_learned(curv_norm_learned_profile, config, labels):
         for i_stat, stat_velocities in enumerate(stats):
             ax = axes[i_stat]
             ax.scatter(
-                filtered["geodesic_dist"],
-                1 / filtered["curv_norm_learned"],
-                c=filtered[stat_velocities],
+                # Note: using the geodesic distance makes the plot
+                # reparameterization invariant.
+                # However, the computation is extremely slow, thus
+                # we recommend using z_grid for the main pipeline
+                # and computing geodesic_dist in a notebook after having selected
+                # a run.
+                # curv_norm_learned_profile["geodesic_dist"],
+                curv_norm_learned_profile["z_grid"],
+                1 / curv_norm_learned_profile["curv_norm_learned"],
+                c=curv_norm_learned_profile[stat_velocities],
                 cmap=cmaps[i_stat],
+            )
+            ax.plot(
+                curv_norm_learned_profile["z_grid"],
+                1 / curv_norm_learned_profile["curv_norm_learned"],
+                c="black",
             )
             ax.set_rlabel_position(-22.5)  # Move radial labels away from plotted line
             ax.grid(True)
@@ -369,8 +381,20 @@ def plot_neural_manifold_learned(curv_norm_learned_profile, config, labels):
         )
 
         ax.scatter(
-            filtered["geodesic_dist"],
-            1 / filtered["curv_norm_learned"],
+            # Note: using the geodesic distance makes the plot
+            # reparameterization invariant.
+            # However, the computation is extremely slow, thus
+            # we recommend using z_grid for the main pipeline
+            # and computing geodesic_dist in a notebook after having selected
+            # a run.
+            # curv_norm_learned_profile["geodesic_dist"],
+            curv_norm_learned_profile["z_grid"],
+            1 / curv_norm_learned_profile["curv_norm_learned"],
+        )
+        ax.plot(
+            curv_norm_learned_profile["z_grid"],
+            1 / curv_norm_learned_profile["curv_norm_learned"],
+            c="black",
         )
         ax.set_rlabel_position(-22.5)  # Move radial labels away from plotted line
         ax.grid(True)


### PR DESCRIPTION
This PR:
- makes the number of grid points (used to compute the curvature profile) different from `n_times`: before, `n_times` was used, which made the computation of the curvature profile extremely long, as `n_times` can be several thousands. The default `n_grid_points` is 100 and it can be changed in `evaluate.py`.
- fixes a bug in the computation of the curvature: the number of grid points and the embedding dim were mixed up
- adds the reparameterization invariant plot of the neural manifold, which is a polar plot whose angle is the geodesic distance between a z0 and the z varying on the grid, and radius is the inverse of the learned curvature.

Note that the computation of the reparameterization invariant manifold uses the geodesic distance: it is extremely long.

In practice, the reparameterization invariant curvature profile could be computed offline (i.e. in a notebook as done in notebook 7) to avoid this compute time. To this aim, the lines computing the `geodesic_dist` have been commented out.
